### PR TITLE
Renaming "Incident Minutes (Accumulated)" widget

### DIFF
--- a/src/content/docs/oma/value-drivers/uptime-performance-and-reliability/use-cases/alert-quality-management/alert-quality-management.json
+++ b/src/content/docs/oma/value-drivers/uptime-performance-and-reliability/use-cases/alert-quality-management/alert-quality-management.json
@@ -54,7 +54,7 @@
             "height": 2,
             "width": 2
           },
-          "title": "Incident Minutes (Accumulated)",
+          "title": "Closed Incident Minutes (Accumulated)",
           "rawConfiguration": {
             "nrqlQueries": [
               {


### PR DESCRIPTION
The query for this widget only sums up the durations of closed incidents. Ongoing open incidents are not included in the calculation. The widget name should be renamed to more accurately reflect this.